### PR TITLE
ci: Add test and code coverage to pull requests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+
+name: Go
+
+on:
+  pull_request:
+
+jobs:
+  tests_and_coverage:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.21.x' ]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: run tests
+        run: go test ./...
+
+      - name: run coverage
+        run: make coverage
+
+      - name: Upload codecov report
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+test:
+	go test ./...
+
 coverage:
 	go test -coverprofile=cover.out ./...
 	go tool cover -func=cover.out


### PR DESCRIPTION
The repo is public. Time to integrate github actions and codecov.io.